### PR TITLE
KT8-80: chore: Configure .gitignore for Python project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# documents
+documents/
+
+# Python
+__pycache__/
+*.pyc
+.env
+venv/
+.venv/


### PR DESCRIPTION
불필요하거나 민감한 파일이 커밋되는 것을 방지하기 위해, Python 프로젝트를 위한 표준 .gitignore 규칙을 추가합니다.